### PR TITLE
adicionado flag FLAG_ACTIVITY_NO_HISTORY ao chamar CustomTabsIntent p…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/onestap/src/main/java/com/onestap/auth/view/ui/widget/OSTAuthActivity.java
+++ b/onestap/src/main/java/com/onestap/auth/view/ui/widget/OSTAuthActivity.java
@@ -94,7 +94,9 @@ public class OSTAuthActivity extends OSTBaseActivity implements AuthContract.Vie
             intentBuilder.setToolbarColor(ContextCompat.getColor(this, OST.getInstance().getConfiguration().getColorPrimary()));
             intentBuilder.setStartAnimations(this, R.anim.slide_in_left, R.anim.slide_out_left);
             intentBuilder.setExitAnimations(this, R.anim.slide_in_right, R.anim.slide_out_right);
-            intentBuilder.build().launchUrl(this, Uri.parse(OST.getInstance().getLoginUrl()));
+            CustomTabsIntent customTabsIntent = intentBuilder.build();
+            customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+            customTabsIntent.launchUrl(this, Uri.parse(OST.getInstance().getLoginUrl()));
 
         }
 


### PR DESCRIPTION
WebView da CustomTabsIntent não fechava após autenticação

<!--

Colocar  na label da issue um ou mais itens abaixo.
[#{bug}|{enhancement}|{documentation}{fire}]

Título: Título bem explicado.

Para mais informações:
https://github.com/stone-payments/onestap-sdk-android/blob/master/CONTRIBUTING.md

-->

# O que foi feito?
  
- Foi adicionado a flag FLAG_ACTIVITY_NO_HISTORY na intent da  CustomTabsIntent

# Por que foi feito?
  
- (Android 7.0) Após realizar a autenticação na webView chamda pela OSTAuthActivity não era possivel fechar essa webView, mesmo limpando a pilha de Activitys

# Como foi feito?

- Foi adicionado a flag FLAG_ACTIVITY_NO_HISTORY na intent da  CustomTabsIntent